### PR TITLE
refine(offload): refine model_unload behavior

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -546,21 +546,22 @@ class LoadedModel:
         return False
 
     def model_unload(self, memory_to_free=None, unpatch_weights=True):
+        model_loaded_size = self.model.loaded_size()
+        if memory_to_free is None:
+            # free the full model
+            memory_to_free = model_loaded_size
+
         logging.debug(f"model_unload: {self.model.model.__class__.__name__}")
         logging.debug(f"memory_to_free: {memory_to_free/(1024*1024*1024)} GB")
         logging.debug(f"unpatch_weights: {unpatch_weights}")
-        logging.debug(f"loaded_size: {self.model.loaded_size()/(1024*1024*1024)} GB")
+        logging.debug(f"loaded_size: {model_loaded_size/(1024*1024*1024)} GB")
         logging.debug(f"offload_device: {self.model.offload_device}")
-
-        if memory_to_free is None:
-            # free the full model
-            memory_to_free = self.model.loaded_size()
 
         available_memory = get_free_memory(self.model.offload_device)
         logging.debug(f"before unload, available_memory of offload device {self.model.offload_device}: {available_memory/(1024*1024*1024)} GB")
 
         mmap_mem_threshold = get_mmap_mem_threshold_gb() * 1024 * 1024 * 1024  # this is reserved memory for other system usage
-        if memory_to_free > available_memory - mmap_mem_threshold or memory_to_free < self.model.loaded_size():
+        if min(memory_to_free, model_loaded_size) > available_memory - mmap_mem_threshold or memory_to_free < model_loaded_size:
             partially_unload = True
         else:
             partially_unload = False
@@ -571,6 +572,8 @@ class LoadedModel:
             logging.debug(f"partially_unload freed vram: {freed/(1024*1024*1024)} GB")
             if freed < memory_to_free:
                 logging.warning(f"Partially unload not enough memory, freed {freed/(1024*1024*1024)} GB, memory_to_free {memory_to_free/(1024*1024*1024)} GB")
+            if freed == model_loaded_size:
+                partially_unload = False
         else:
             logging.debug("Do full unload")
             self.model.detach(unpatch_weights)


### PR DESCRIPTION
基于 [refine_offload](https://github.com/siliconflow/ComfyUI/pull/13) 分支。对 `comfy/model_management.py` 的 `model_unload` 函数进行一些修改。

首先是当前实现中可能出现 `None / int` 的问题，应将检查并修改 `memory_to_free` 提前
```python
    def model_unload(self, memory_to_free=None, unpatch_weights=True):
        ...
        logging.debug(f"memory_to_free: {memory_to_free/(1024*1024*1024)} GB") # 此处可能出现 None / (1024 ** 3)
        ...
        if memory_to_free is None:
            # free the full model
            memory_to_free = self.model.loaded_size()
```

同时我认为 `partially_unload` 的设置不够精细。比如当 OOM 发生时会将 `memory_to_free` 设为一个极大值，则所有已载入模型均会使用 partially_unload 方式进行 offload。取 `min(memory_to_free, 当前模型载入大小)` 相对更精细一些。

以及当前实现直接根据 `partially_unload` 返回，但当前部分卸载的逻辑应可能存在完整卸载模型的情况，检查模型是否被完整卸载再返回，更符合原函数的行为。